### PR TITLE
Add support for Laravel 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Laravel Queue worker that's safe for use with Laravel Doctrine
 
 #### When to use SafeQueue
 
-- [x] You use Laravel 5 or 6
+- [x] You use Laravel 5, 6 or 7
 - [x] You use Laravel Doctrine
 - [x] Devops say the CPU usage of `queue:listen` is unacceptable
 - [x] You want to do `php artisan queue:work --daemon` without hitting cascading `EntityManager is closed` exceptions
@@ -21,7 +21,7 @@ Version | Supported Laravel Versions
 0.1.* | 5.1, 5.2 
 0.2.* | ^5.3.16 
 0.3.* | ^5.4.9
-0.4.* | ^6.0.5
+0.4.* | ^6.0.5, ^7.0
 
 #### How it Works
 

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "illuminate/queue": "^6.0",
+        "php": "^7.2",
+        "illuminate/queue": "^6.0|^7.0",
         "laravel-doctrine/orm": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12f16725f282dc12e62a8b6ce6c72779",
+    "content-hash": "7f1ca3206b6e60979d4d624a3277de1a",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1427,16 +1427,16 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v6.0.4",
+            "version": "v6.18.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
-                "reference": "5e667f06e4ee8cad830aa6f18ae01f503ad83afc"
+                "reference": "e362b16043e4c7ffaffc82ae7496b184c05e3807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/queue/zipball/5e667f06e4ee8cad830aa6f18ae01f503ad83afc",
-                "reference": "5e667f06e4ee8cad830aa6f18ae01f503ad83afc",
+                "url": "https://api.github.com/repos/illuminate/queue/zipball/e362b16043e4c7ffaffc82ae7496b184c05e3807",
+                "reference": "e362b16043e4c7ffaffc82ae7496b184c05e3807",
                 "shasum": ""
             },
             "require": {
@@ -1463,7 +1463,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.x-dev"
                 }
             },
             "autoload": {
@@ -1483,7 +1483,7 @@
             ],
             "description": "The Illuminate Queue package.",
             "homepage": "https://laravel.com",
-            "time": "2019-09-11T12:03:36+00:00"
+            "time": "2020-03-12T11:32:25+00:00"
         },
         {
             "name": "illuminate/routing",
@@ -5477,7 +5477,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6"
+        "php": "^7.2"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Hi @motia 

@dps.lwk suggested I do a PR here rather than the original repo.

This adds Laravel 7.x support. `illuminate/queue` 7.x appears to be backwards compatible with `illuminate/queue` 6.x - the major version bump there seems just to be to match the current Laravel framework version.

Summary of changes:

- Allowed `illuminate/queue` 7.x as well as 6.x to satisfy dependencies
- Bumped required PHP version to `^7.2` for good measure (now matches the requirement in `illuminate/queue` 6.x)
- Updated lock file (seeing as it's their, although I believe it would be ignored by a parent application depending on this package)
- Ran the tests, which pass